### PR TITLE
Change NLogLog to use wrapper type on all log calls to maintain call stack

### DIFF
--- a/LoggingExtensions.NLog.Sample/App.config
+++ b/LoggingExtensions.NLog.Sample/App.config
@@ -13,7 +13,7 @@
             overflowAction="Discard">
         <target type="File"
               fileName="${basedir}/logs/this.Log-NLog.Sample.log"
-              layout="${longdate} ${threadid} [${level:uppercase=true}] ${message}"
+              layout="${longdate} ${threadid} [${level:uppercase=true}] ${callsite:className=true:fileName=false:includeSourcePath=false:methodName=true} ${message}"
               />
       </target>
       <target name="errorSmtp" type="Mail"

--- a/LoggingExtensions.NLog/NLogLog.cs
+++ b/LoggingExtensions.NLog/NLogLog.cs
@@ -19,66 +19,66 @@ namespace LoggingExtensions.NLog
 
         public void Debug(string message, params object[] formatting)
         {
-            if (_logger.IsDebugEnabled) _logger.Debug(message, formatting);
+            if (_logger.IsDebugEnabled) _logger.Log(typeof(NLogLog), new LogEventInfo(LogLevel.Debug, _logger.Name, message));
         }
 
         public void Debug(Func<string> message)
         {
-            if (_logger.IsDebugEnabled) _logger.Debug(message());
+            if (_logger.IsDebugEnabled) _logger.Log(typeof(NLogLog), new LogEventInfo(LogLevel.Debug, _logger.Name, message()));
         }
 
         public void Info(string message, params object[] formatting)
         {
-           if (_logger.IsInfoEnabled) _logger.Info(message, formatting);
+            if (_logger.IsInfoEnabled) _logger.Log(typeof(NLogLog), new LogEventInfo(LogLevel.Info, _logger.Name, string.Format(message, formatting)));
         }
 
         public void Info(Func<string> message)
         {
-            if (_logger.IsInfoEnabled) _logger.Info(message());
+            if (_logger.IsInfoEnabled) _logger.Log(typeof(NLogLog), new LogEventInfo(LogLevel.Info, _logger.Name, message()));
         }
 
         public void Warn(string message, params object[] formatting)
         {
-           if (_logger.IsWarnEnabled) _logger.Warn(message, formatting);
+            if (_logger.IsWarnEnabled) _logger.Log(typeof(NLogLog), new LogEventInfo(LogLevel.Warn, _logger.Name, string.Format(message, formatting)));
         }
 
         public void Warn(Func<string> message)
         {
-            if (_logger.IsWarnEnabled) _logger.Warn(message());
+            if (_logger.IsWarnEnabled) _logger.Log(typeof(NLogLog), new LogEventInfo(LogLevel.Warn, _logger.Name, message()));
         }
 
         public void Error(string message, params object[] formatting)
         {
             // don't check for enabled at this level
-            _logger.Error(message, formatting);
+            _logger.Log(typeof(NLogLog), new LogEventInfo(LogLevel.Error, _logger.Name, string.Format(message, formatting)));
         }
 
         public void Error(Func<string> message)
         {
             // don't check for enabled at this level
-             _logger.Error(message());
+            _logger.Log(typeof(NLogLog), new LogEventInfo(LogLevel.Error, _logger.Name, message()));
         }
 
         public void Error(Func<string> message, Exception exception)
         {
-            _logger.ErrorException(message(),exception);
+            _logger.Log(typeof(NLogLog), new LogEventInfo(LogLevel.Error, _logger.Name, message()) { Exception = exception });
         }
 
         public void Fatal(string message, params object[] formatting)
         {
             // don't check for enabled at this level
-            _logger.Fatal(message, formatting);
+            _logger.Log(typeof(NLogLog), new LogEventInfo(LogLevel.Fatal, _logger.Name, string.Format(message, formatting)));
         }
 
         public void Fatal(Func<string> message)
         {
             // don't check for enabled at this level
-            _logger.Fatal(message());
+            _logger.Log(typeof(NLogLog), new LogEventInfo(LogLevel.Fatal, _logger.Name, message()));
         }
 
         public void Fatal(Func<string> message, Exception exception)
         {
-            _logger.FatalException(message(),exception);
+            _logger.Log(typeof(NLogLog), new LogEventInfo(LogLevel.Fatal, _logger.Name, message()) { Exception = exception });
         }
     }
 }

--- a/LoggingExtensions.NLog/NLogLog.cs
+++ b/LoggingExtensions.NLog/NLogLog.cs
@@ -19,7 +19,7 @@ namespace LoggingExtensions.NLog
 
         public void Debug(string message, params object[] formatting)
         {
-            if (_logger.IsDebugEnabled) _logger.Log(typeof(NLogLog), new LogEventInfo(LogLevel.Debug, _logger.Name, message));
+            if (_logger.IsDebugEnabled) _logger.Log(typeof(NLogLog), new LogEventInfo(LogLevel.Debug, _logger.Name, string.Format(message, formatting)));
         }
 
         public void Debug(Func<string> message)


### PR DESCRIPTION
Hey, I noticed that when using NLog the callstack layout renderer was not displaying the correct information. This is because the NLogLog wrapper must use the .Log(Type wrapperType...) to let NLog know that it is just a wrapper. I changed the NLogLog class to pass in the wrapperType to fix it.

Thanks,
Alden