### PR TITLE
Change log4net dependency to [2.0,3.0)

### DIFF
--- a/LoggingExtensions.log4net/LoggingExtensions.log4net.csproj
+++ b/LoggingExtensions.log4net/LoggingExtensions.log4net.csproj
@@ -37,9 +37,9 @@
     <AssemblyOriginatorKeyFile>..\LoggingExtensions.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="log4net, Version=1.2.10.0, Culture=neutral, PublicKeyToken=1b44e1d426115821, processorArchitecture=MSIL">
-      <Private>True</Private>
-      <HintPath>..\packages\log4net.1.2.10\lib\2.0\log4net.dll</HintPath>
+    <Reference Include="log4net, Version=1.2.13.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\log4net.2.0.3\lib\net40-full\log4net.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/LoggingExtensions.log4net/packages.config
+++ b/LoggingExtensions.log4net/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="log4net" version="1.2.10" targetFramework="net40" allowedVersions="[1.2.10]" />
+  <package id="log4net" version="2.0.3" targetFramework="net40" />
 </packages>

--- a/LoggingExtensions.log4net/this.log-log4net.nuspec
+++ b/LoggingExtensions.log4net/this.log-log4net.nuspec
@@ -20,8 +20,8 @@
     <copyright>Copyright 2012</copyright>
     <tags>logging log this.Log log4net</tags>
     <dependencies>
-      <dependency id="this.Log" version="0.0.3.0" />
-      <dependency id="log4net" version="[1.2.10]" />
+      <dependency id="this.Log" version="0.0.4.0" />
+      <dependency id="log4net" version="[2.0,3.0)" />
     </dependencies>
   </metadata>
   <files>

--- a/SharedAssembly.cs
+++ b/SharedAssembly.cs
@@ -8,5 +8,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCulture("")]
 [assembly: ComVisible(false)]
 
-[assembly: AssemblyVersion("0.0.3.0")]
-[assembly: AssemblyFileVersion("0.0.3.0")]
+[assembly: AssemblyVersion("0.0.4.0")]
+[assembly: AssemblyFileVersion("0.0.4.0")]


### PR DESCRIPTION
Hey Rob, wanted to use log4net 2 on a project with this.Log but ran into the hard 1.2.10 dependency.  Updating doesn't seem to break anything.  Thanks man!
